### PR TITLE
"LA-2251,LA-2251 bug fix and removing delete functionality"

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -4,14 +4,24 @@ import { JSONEditor } from "../lib";
 // to compile a production version
 //npm publish to publish
 
+
+
 const App = () => {
 
   useEffect(()=>{
-   console.log("api intigration")
+  console.log("api loaded")
   },[])
-return (
-  <div>   
-    <h3>Simple Json editor</h3>
+
+  return (
+    <div>
+    <h3>Using default styles</h3>
+    <JSONEditor
+      data={data}
+      // view="dual"
+      collapsible
+      onChange={this.onJsonChange}
+    />
+    <h3>Using customized styles</h3>
     <JSONEditor
       data={data}
       // view="dual"
@@ -21,7 +31,8 @@ return (
     />
   </div>
   )
-}
+  
+  }
 
 const styles = {
   dualView: {
@@ -47,7 +58,7 @@ const styles = {
     /*color: "#3E3D32"*/
   },
   label: {
-    color: "red",
+    color: "DeepPink",
     marginTop: 3,
   },
   value: {
@@ -116,34 +127,40 @@ const styles = {
   },
 };
 
-const data ={
-  name: "monica",
-  age: null,
-  match: true,
-  address: [
-    "Panyu Shiqiao on Canton",
-    "Tianhe",
-    {
-      city: "forida meta 11",
+const data = {
+  mobile: {
+    possibleCountryCodes: ["KE", "UG", "TZ"],
+    possibleLengths: {
+      national: "5",
+      sub_national: "7",
     },
-  ],
-  others: {
-    id: 1246,
-    joinTime: "2017-08-20. 10:20",
-    description: "another",
+    exampleNumber: 40123,
+    nationalNumberPattern: "4\\d{4}",
   },
-  employees: [
-    { name: "Ram", email: "ram@gmail.com", age: 23 },
-    { name: "Shyam", email: "shyam23@gmail.com", age: 28 },
-    { name: "John", email: "john@gmail.com", age: 33 },
-    { name: "Bob", email: "bob32@gmail.com", age: 41 },
-  ],
-  member: [
-    { name: "Ram", email: "ram@gmail.com", age: 23 },
-    { name: "Shyam", email: "shyam23@gmail.com", age: 28 },
-    { name: "John", email: "john@gmail.com", age: 33 },
-    { name: "Bob", email: "bob32@gmail.com", age: 41 },
-  ]
-}
+  id: "AC",
+  is_valid_number: true,
+  generalDesc: {
+    nationalNumberPattern: "[46]\\d{4}|[01589]\\d{5}",
+  },
+  countryCode: "247",
+  uan: {
+    possibleLengths: {
+      national: "6",
+    },
+    exampleNumber: 542011,
+    nationalNumberPattern: "[01589]\\d{5}",
+  },
+  references: {
+    sourceUrl: "http://www.itu.int/oth/T02020000AF/en",
+  },
+  internationalPrefix: "00",
+  fixedLine: {
+    possibleLengths: {
+      national: "5",
+    },
+    exampleNumber: 62889,
+    nationalNumberPattern: "6[2-467]\\d{3}",
+  },
+};
 
 export default App;

--- a/src/lib/JSONEditor.js
+++ b/src/lib/JSONEditor.js
@@ -130,14 +130,13 @@ export default class JSONEditor extends React.Component {
     if (isArray(data)) {
       if (marginLeft > 0) {
         //special case to avoid showing root
-        // parent node
         elems.push(
           <ParentLabel
             key={getKey("parent_label", currentKey, parentKeyPath, marginLeft)}
             value={label}
             addElement={this.addElement}
             removeElement={this.removeElement}
-           // showRemoveButton={this.props.showRemoveButton}
+            showRemoveButton={this.props.showRemoveButton}
             showAddButton={this.props.showAddButton}
             current={data}
             parent={parent}
@@ -164,7 +163,6 @@ export default class JSONEditor extends React.Component {
     } else if (isObject(data)) {
       if (marginLeft > 0) {
         //special case to avoid showing root
-        // root node
         elems.push(
           <ParentLabel
             key={getKey("parent_label", currentKey, parentKeyPath, marginLeft)}
@@ -172,7 +170,7 @@ export default class JSONEditor extends React.Component {
             addElement={this.addElement}
             removeElement={this.removeElement}
             showRemoveButton={this.props.showRemoveButton}
-          //  showAddButton={this.props.showAddButton}
+            showAddButton={this.props.showAddButton}
             current={data}
             parent={parent}
             marginLeft={marginLeft}
@@ -203,7 +201,7 @@ export default class JSONEditor extends React.Component {
           marginBottom={this.props.marginBottom}
           removeElement={this.removeElement}
           saveElement={this.saveElement}
-         // showRemoveButton={this.props.showRemoveButton}
+          showRemoveButton={this.props.showRemoveButton}
           showAddButton={this.props.showAddButton}
           label={label}
           type="number"
@@ -222,7 +220,7 @@ export default class JSONEditor extends React.Component {
           marginBottom={this.props.marginBottom}
           removeElement={this.removeElement}
           saveElement={this.saveElement}
-         // showRemoveButton={this.props.showRemoveButton}
+          showRemoveButton={this.props.showRemoveButton}
           showAddButton={this.props.showAddButton}
           label={label}
           type="text"
@@ -240,7 +238,7 @@ export default class JSONEditor extends React.Component {
           marginLeft={marginLeft}
           marginBottom={this.props.marginBottom}
           removeElement={this.removeElement}
-        // showRemoveButton={this.props.showRemoveButton}
+          showRemoveButton={this.props.showRemoveButton}
           showAddButton={this.props.showAddButton}
           parent={parent}
           currentKey={currentKey}
@@ -256,14 +254,8 @@ export default class JSONEditor extends React.Component {
   addElement = (parent) => {
     let newKey = null;
     if (isArray(parent)) {
-      if (typeof parent[0] == 'object') {
-				var obj2 = JSON.parse(JSON.stringify(parent[parent.length - 1]));
-				parent.splice(parent.length - 1, 0, obj2);
-				newKey = parent.length - 1;
-			} else {
-				parent.push('');
-				newKey = parent.length - 1;
-			}
+      parent.push("");
+      newKey = parent.length - 1;
     } else {
       newKey = EDIT_KEY;
       parent[newKey] = "";


### PR DESCRIPTION
1. Changed the data object JSON with nested data structures like an array of objects. Lib-provided JSON doesn't have the nested data structure.

2. Commented the "showRemoveButton" function props for the required Data structure so that lib will not allow the user to delete the node. now it will not show the "cross" icon on hover to single node data structures.
![image](https://github.com/pepcus-Aish/simpleJSONEditordemo/assets/141809285/fc62707e-88fd-44a1-8460-d8ef9c7e2987)
  

3. I have not removed the "showRemoveButton" function just commented as keeping it available for future scope which found to be achieved by only uncommenting it.

4. In the addElement functionality earlier if the user clicked the "+" icon of the parent node only a single node of string data type is added but now I have added the code to replicate the last object in an Array of object case only and single node replication for other cases so that object is replicated with same nested nodes.

5. The user can now remove the node of its choice in the array of objects only.
 